### PR TITLE
[12.0] [FIX] Removendo o imposto originador da conta de dedução de venda. 

### DIFF
--- a/br_account/models/account_invoice.py
+++ b/br_account/models/account_invoice.py
@@ -359,7 +359,6 @@ class AccountInvoice(models.Model):
                 done_taxes.append(tax.id)
                 res.append({
                     'invoice_tax_line_id': tax_line.id,
-                    'tax_line_id': tax_line.tax_id.id,
                     'type': 'tax',
                     'name': tax_line.name,
                     'price_unit': tax_line.amount * -1,

--- a/br_nfse_ginfes/reports/danfse_ginfes.xml
+++ b/br_nfse_ginfes/reports/danfse_ginfes.xml
@@ -139,10 +139,10 @@
                         <div class="col-2 linha br">
                             <span t-field="doc.company_id.cnpj_cpf" />
                         </div>
-                        <div class="col-1 rotulo br">
-                            Inscr. Munic.
+                        <div class="col-2 rotulo br">
+                            Insc. Municipal
                         </div>
-                        <div class="col-2 linha br">
+                        <div class="col-1 linha br">
                             <span t-field="doc.company_id.inscr_mun" />
                         </div>
                         <div class="col-1 rotulo br">
@@ -205,10 +205,10 @@
                 <div class="col-2 linha br">
                     <span t-field="doc.commercial_partner_id.cnpj_cpf" />
                 </div>
-                <div class="col-1 rotulo br">
-                    Inscr. Municipal
+                <div class="col-2 rotulo br">
+                    Insc. Municipal
                 </div>
-                <div class="col-2 linha br">
+                <div class="col-1 linha br">
                     <span t-field="doc.commercial_partner_id.inscr_mun" />
                 </div>
                 <div class="col-1 rotulo br">


### PR DESCRIPTION
Removendo o imposto originador da conta de dedução de venda. Este campo afeta a visualização de relatórios de apuração de impostos.