### PR TITLE
[11.0] [FIX] Removendo o imposto originador da conta de dedução de venda. 

### DIFF
--- a/br_account/models/account_invoice.py
+++ b/br_account/models/account_invoice.py
@@ -367,7 +367,6 @@ class AccountInvoice(models.Model):
                 done_taxes.append(tax.id)
                 res.append({
                     'invoice_tax_line_id': tax_line.id,
-                    'tax_line_id': tax_line.tax_id.id,
                     'type': 'tax',
                     'name': tax_line.name,
                     'price_unit': tax_line.amount * -1,


### PR DESCRIPTION
Este parâmetro afeta o uso de relatórios de apuração de impostos já que todos acabando trazendo as duas linhas vinculadas ao imposto e com isso o valor do imposto é zerado. 

https://github.com/Trust-Code/odoo-brasil/issues/919