### PR TITLE
[FIX] Simples Nacional Tipo 2

### DIFF
--- a/br_account/views/account_invoice_view.xml
+++ b/br_account/views/account_invoice_view.xml
@@ -279,8 +279,8 @@
                         <page name="icms" string="ICMS" attrs="{'invisible': [('product_type', '=', 'service')]}">
                             <group name="detalhes_icms" string="Detalhes do ICMS">
                                 <group>
-                                    <field name="icms_cst_normal" attrs="{'invisible': [('company_fiscal_type', '!=', '3')] }" />
-                                    <field name="icms_csosn_simples" attrs="{'invisible': [('company_fiscal_type', '==', '3')] }" />
+                                    <field name="icms_cst_normal" attrs="{'invisible': [('company_fiscal_type', '==', '1')] }" />
+                                    <field name="icms_csosn_simples" attrs="{'invisible': [('company_fiscal_type', '!=', '1')] }" />
                                     <field name="icms_origem"/>
                                     <field name="icms_tipo_base" invisible="1"/>
                                     <field name="incluir_ipi_base" />


### PR DESCRIPTION
Correção Simples Nacional Tipo 2

Na Nota Fiscal Eletrônica, na aba “Produtos e Serviços” / “Tributos” / “ICMS”, o contribuinte terá duas opções de marcação: “Tributação Normal” ou “Simples Nacional”. Selecionando a opção “Tributação Normal”, o programa irá habilitar os Códigos de Situação Tributária (CST) para o contribuinte selecionar. Selecionando a opção “Simples Nacional”, o programa irá habilitar os códigos CSOSN. Caso o contribuinte esteja dentro do caso de “excesso de sublimite de receita bruta”, para efeito de preenchimento da aba ICMS, deverá selecionar a opção “Tributação Normal”.