### PR TITLE
[FIX] Correção campo desconto2 e descont3 na geracao cnab BB

### DIFF
--- a/br_cnab/febraban/cnab_240/bancos/banco_brasil.py
+++ b/br_cnab/febraban/cnab_240/bancos/banco_brasil.py
@@ -31,6 +31,8 @@ class BancoBrasil240(Cnab240):
         vals['prazo_baixa'] = ''
         vals['controlecob_numero'] = self.order.id
         vals['controlecob_data_gravacao'] = self.data_hoje()
+        vals['desconto2_percentual'] = Decimal('0.00')
+        vals['desconto3_percentual'] = Decimal('0.00')
         # Codigo juro mora:
         # 1 - Valor ao dia
         # 2 - Taxa Mensal


### PR DESCRIPTION
Por ora corrigi no modulo Odoo mas acredito que possa ser feita correção na lib python3_cnab ou pycnab240